### PR TITLE
Fix invalid paths on Non-Windows systems

### DIFF
--- a/Editor/CodeGeneration/Data/AssetsInfo.cs
+++ b/Editor/CodeGeneration/Data/AssetsInfo.cs
@@ -25,8 +25,8 @@ namespace RoRSkinBuilder.Data
             this.skinModInfo = skinModInfo;
             uccModName = skinModInfo.modName.ToUpperCamelCase();
             assetBundleName = (skinModInfo.author.ToUpperCamelCase() + uccModName).ToLower();
-            assetBundlePath = "SkinModAssets\\" + uccModName;
-            modFolder = "Assets\\SkinMods\\" + uccModName;
+            assetBundlePath = Path.Combine("SkinModAssets", uccModName);
+            modFolder = Path.Combine("Assets", "SkinMods", uccModName);
         }
 
         public void CreateNecessaryAssetsAndFillPaths()


### PR DESCRIPTION
Before, due to the backslahses, The script tries to create a single folder called `Assets\SkinMods\{modname}`, which breaks everything that tries to access files with a path. Using Path.Combine like the rest of the code makes it create directories correctly